### PR TITLE
Removes extraneous comma on landing page

### DIFF
--- a/themes/urssi/layouts/index.html
+++ b/themes/urssi/layouts/index.html
@@ -39,13 +39,13 @@
     </b>
     ,
     <b>
-        development,
+        development
     </b>
-    and
+    , and
     <b>
         use
     </b>
-    , of software for a more sustainable research enterprise.
+    of software for a more sustainable research enterprise.
 </p>
 						<a href="{{.Site.BaseURL}}about" class="btn btn-action-1">
 									Learn more about our mission and vision


### PR DESCRIPTION
There was an extra comma in the URSSI one-line description on the landing page: "recognition, development, and use, of software", that this removes